### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-test.yaml
+++ b/.github/workflows/maven-test.yaml
@@ -1,4 +1,6 @@
 name: Multi-Module Maven Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Hanzm10/Hardware-Inventory-Sales/security/code-scanning/1](https://github.com/Hanzm10/Hardware-Inventory-Sales/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, the only permission needed is `contents: read`, as the workflow involves checking out the repository, setting up Java, building the project, running tests, and uploading test reports. None of these steps require write permissions.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
