### PR TITLE
 🐛 fix cleanup bug: closes #77 #78 

### DIFF
--- a/murico-swingapp/src/main/java/com/github/hanzm_10/murico/swingapp/lib/navigation/manager/SceneManager.java
+++ b/murico-swingapp/src/main/java/com/github/hanzm_10/murico/swingapp/lib/navigation/manager/SceneManager.java
@@ -9,20 +9,20 @@ import com.github.hanzm_10.murico.swingapp.lib.navigation.guard.SceneGuard;
 import com.github.hanzm_10.murico.swingapp.lib.navigation.scene.Scene;
 
 public interface SceneManager {
-    void navigateTo(@NotNull final String sceneName);
+	void destroy();
 
-    void registerScene(@NotNull final String sceneName, @NotNull final SceneFactory sceneFactory);
+	String getCurrentSceneName();
 
-    void registerScene(@NotNull final String sceneName, @NotNull final SceneFactory sceneFactory,
-            @NotNull final SceneGuard sceneGuard);
+	JPanel getRootContainer();
 
-    void unregisterScene(@NotNull final String sceneName);
+	Scene getScene(@NotNull final String sceneName);
 
-    void destroy();
+	void navigateTo(@NotNull final String sceneName);
 
-    Scene getScene(@NotNull final String sceneName);
+	void registerScene(@NotNull final String sceneName, @NotNull final SceneFactory sceneFactory);
 
-    String getCurrentSceneName();
+	void registerScene(@NotNull final String sceneName, @NotNull final SceneFactory sceneFactory,
+			@NotNull final SceneGuard sceneGuard);
 
-    JPanel getRootContainer();
+	void unregisterScene(@NotNull final String sceneName);
 }

--- a/murico-swingapp/src/main/java/com/github/hanzm_10/murico/swingapp/lib/navigation/manager/impl/StaticSceneManager.java
+++ b/murico-swingapp/src/main/java/com/github/hanzm_10/murico/swingapp/lib/navigation/manager/impl/StaticSceneManager.java
@@ -50,8 +50,6 @@ public class StaticSceneManager implements SceneManager {
 		super();
 
 		cardLayout = new CardLayout();
-		cardLayout.setHgap(0);
-		cardLayout.setVgap(0);
 		rootContainer = new JPanel(cardLayout);
 		registeredSceneEntries = new HashMap<>();
 		sceneCache = new ObserverLRU<>(10);

--- a/murico-swingapp/src/main/java/com/github/hanzm_10/murico/swingapp/lib/navigation/manager/impl/StaticSceneManager.java
+++ b/murico-swingapp/src/main/java/com/github/hanzm_10/murico/swingapp/lib/navigation/manager/impl/StaticSceneManager.java
@@ -90,7 +90,7 @@ public class StaticSceneManager implements SceneManager {
 			LOGGER.severe("Scene view is null before destroy of scene: " + scene.getSceneName());
 		}
 
-		sceneCache.remove(scene.getSceneName());
+		sceneCache.remove(scene.getSceneName(), false);
 		rootContainer.remove(scene.getSceneView());
 		scene.onDestroy();
 

--- a/murico-swingapp/src/main/java/com/github/hanzm_10/murico/swingapp/lib/navigation/scene/Scene.java
+++ b/murico-swingapp/src/main/java/com/github/hanzm_10/murico/swingapp/lib/navigation/scene/Scene.java
@@ -2,46 +2,59 @@ package com.github.hanzm_10.murico.swingapp.lib.navigation.scene;
 
 import javax.swing.JPanel;
 
+import com.github.hanzm_10.murico.swingapp.lib.navigation.manager.SceneManager;
+
 public interface Scene {
-    String getSceneName();
+	default boolean canHide() {
+		return true;
+	}
 
-    JPanel getSceneView();
+	default boolean canShow() {
+		return true;
+	}
 
-    default boolean supportsSubScenes() {
-        return this instanceof SubSceneSupport;
-    }
+	/**
+	 *
+	 * @return The name that {@link SceneManager} will use for accessing this scene
+	 *         in its cache for navigation.
+	 */
+	String getSceneName();
 
-    default boolean canShow() {
-        return true;
-    }
+	/**
+	 * This is where a {@link Scene} should typically create its view if it doesn't
+	 * exist yet.
+	 *
+	 * @return
+	 */
+	JPanel getSceneView();
 
-    default void onBeforeShow() {
-    }
+	default Scene getSelf() {
+		return this;
+	}
 
-    default void onShow() {
-    }
+	default void onBeforeHide() {
+	}
 
-    default boolean canHide() {
-        return true;
-    }
+	default void onBeforeShow() {
+	}
 
-    default void onCannotHide() {
-    }
+	default void onCannotHide() {
+	}
 
-    default void onBeforeHide() {
-    }
+	void onCreate();
 
-    default void onHide() {
-    }
+	default boolean onDestroy() {
+		return true;
+	}
 
-    void onCreate();
+	default void onHide() {
+	}
 
-    default boolean onDestroy() {
-        return true;
-    }
+	default void onShow() {
+	}
 
-    default Scene getSelf() {
-        return this;
-    }
+	default boolean supportsSubScenes() {
+		return this instanceof SubSceneSupport;
+	}
 
 }

--- a/murico-swingapp/src/test/java/com/github/hanzm_10/murico/swingapp/lib/cache/TestsObserverLRU.java
+++ b/murico-swingapp/src/test/java/com/github/hanzm_10/murico/swingapp/lib/cache/TestsObserverLRU.java
@@ -1,0 +1,59 @@
+package com.github.hanzm_10.murico.swingapp.lib.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.github.hanzm_10.murico.swingapp.lib.observer.Subscriber;
+
+public class TestsObserverLRU {
+	@Test
+	@DisplayName("test trimCache() to only notify subscribers when exceeding limit.")
+	void testObserver() {
+		ObserverLRU<String, String> lruObs = new ObserverLRU<String, String>(2);
+		var isCalled = new AtomicBoolean(false);
+		Subscriber<String> l = (_) -> {
+			isCalled.set(true);
+		};
+
+		lruObs.subscribe(l);
+		lruObs.update("foo", "bar");
+		lruObs.update("deez", "nuts");
+
+		assertFalse(isCalled.get());
+
+		lruObs.update("say", "what");
+
+		assertTrue(isCalled.get());
+
+		lruObs.unsubscribe(l);
+	}
+
+	@Test
+	@DisplayName("test ObserverLRU to not cause indirect recursion when remove() is called by a subscriber")
+	void testObserverIndirectRecursion() {
+		ObserverLRU<String, String> lruObs = new ObserverLRU<String, String>(2);
+		var calls = new AtomicInteger(0);
+		Subscriber<String> l2 = (s) -> {
+			// basically, if the remove() invocation inside this lambda function calls this
+			// subscriber lambda function, then calls != 0 by then. Verifies that the
+			// subscriber is only ever called once for the same key that's being removed
+			assertEquals(0, calls.getAndIncrement());
+			assertNotNull(s);
+			lruObs.remove("foo");
+		};
+
+		lruObs.update("foo", "bar");
+		lruObs.update("deez", "nuts");
+		lruObs.subscribe(l2);
+		lruObs.remove("foo");
+		lruObs.unsubscribe(l2);
+	}
+}


### PR DESCRIPTION
Now, `ObserverLRU` checks if its parent returns a `null` value before notifying its subscribers. If the value is `null`, then nothing was removed, so notifying its subscribers would be pointless and lead to the aforementioned issues and other bugs.

```java
@Override
public synchronized V remove(K key) {
	var val = super.remove(key);

	if (val != null) {
		notifySubscribers(val);
	}

	return val;
}
@Override
protected V trimCache() {
	var val = super.trimCache();

	if (val != null) {
		notifySubscribers(val);
	}

	return val;
}
```

Also, to fully fix the cleanup issue where we are unintentionally causing indirect recursion. An implementation for `ObserverLRU` has been made so that a subscriber that calls `remove()` can optionally tell the `ObserverLRU` to not notify it since it should be aware that it's been removed.

`ObserverLRU.java`
```java
/**
  * Used for whenever a caller, that's also a subscriber, does not need to be
  * updated since it's contextually aware that the item it's trying to remove is,
  * well... removed. Of course if {@code V} is null, then the subscribers will
  * also simply not be called.
  *
  * @param key
  * @param shouldPublishUpdate
  * @return
  */
public synchronized V remove(K key, boolean shouldPublishUpdate) {
	var val = super.remove(key);

	if (val != null && shouldPublishUpdate) {
		notifySubscribers(val);
	}

	return val;
}
```

The culprit calling line:

`StaticSceneManager.java`
```java
sceneCache.remove(scene.getSceneName(), false);
rootContainer.remove(scene.getSceneView());
scene.onDestroy();
```

closes #77 
closes #78

Result (Don't mind the logs about scene manager being destroyed as that functionality is not yet available for this pull request. It will be separate):

![image](https://github.com/user-attachments/assets/f45ee101-e8e7-4d46-8b84-8e50248fa49d)
